### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,46 @@
 *.class
 
 # Package Files #
-*.jar
 *.war
 *.ear
+
+# Eclipse (project and classpath files are currently included)
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+
+# Local configuration file (sdk path, etc)
+local.properties
+.settings/
+
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# PDT-specific
+.buildpath
+
+
+# Windows & Mac stuff
+
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Mac custom attributes
+.DS_Store


### PR DESCRIPTION
Many unnecessary files are now excluded: files in bin/ & tmp/,
.settings/ files, *.tmp files, etc. Jar files are included now to make
using libraries easier.
