### PR TITLE
Canfield -> Canfield-Staging

### DIFF
--- a/bubolo/src/bubolo/BuboloApplication.java
+++ b/bubolo/src/bubolo/BuboloApplication.java
@@ -24,12 +24,12 @@ public class BuboloApplication implements GameApplication
 	/**
 	 * The number of game ticks (calls to <code>update</code>) per second.
 	 */
-	public static final int TICKS_PER_SECOND = 30;
+	public static final long TICKS_PER_SECOND = 30;
 	
 	/**
 	 * The number of milliseconds per game tick.
 	 */
-	public static final float MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
+	public static final long MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
 	
 	/**
 	 * Constructs an instance of the game application. Only one instance should 

--- a/bubolo/test/bubolo/integration/AudioTestApplication.java
+++ b/bubolo/test/bubolo/integration/AudioTestApplication.java
@@ -43,17 +43,17 @@ public class AudioTestApplication implements GameApplication
 	private boolean ready;
 	
 	private int frame = 0;
-	private int MAX_FRAMES = TICKS_PER_SECOND * 15;
+	private long MAX_FRAMES = TICKS_PER_SECOND * 15;
 	
 	/**
 	 * The number of game ticks (calls to <code>update</code>) per second.
 	 */
-	public static final int TICKS_PER_SECOND = 30;
+	public static final long TICKS_PER_SECOND = 30;
 	
 	/**
 	 * The number of milliseconds per game tick.
 	 */
-	public static final float MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
+	public static final long MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
 	
 	/**
 	 * Constructs an instance of the game application. Only one instance should 

--- a/bubolo/test/bubolo/integration/CollisionTestApplication.java
+++ b/bubolo/test/bubolo/integration/CollisionTestApplication.java
@@ -116,13 +116,16 @@ public class CollisionTestApplication implements GameApplication
 		graphics.draw(world);
 		world.update();
 
+		// (cdc - 4/3/2014): Commented out, b/c update was being called twice. Additionally,
+		// the game is extremely jittery when this is used instead of calling update continuously. 
+		
 		// Ensure that the world is only updated as frequently as MILLIS_PER_TICK.
-		long currentMillis = System.currentTimeMillis();
-		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
-		{
-			world.update();
-			lastUpdate = currentMillis;
-		}
+//		long currentMillis = System.currentTimeMillis();
+//		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
+//		{
+//			world.update();
+//			lastUpdate = currentMillis;
+//		}
 	}
 
 	/**

--- a/bubolo/test/bubolo/integration/GraphicsTestApplication.java
+++ b/bubolo/test/bubolo/integration/GraphicsTestApplication.java
@@ -57,12 +57,12 @@ public class GraphicsTestApplication implements GameApplication
 	/**
 	 * The number of game ticks (calls to <code>update</code>) per second.
 	 */
-	public static final int TICKS_PER_SECOND = 30;
+	public static final long TICKS_PER_SECOND = 30;
 	
 	/**
 	 * The number of milliseconds per game tick.
 	 */
-	public static final float MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
+	public static final long MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
 	
 	/**
 	 * Constructs an instance of the game application. Only one instance should 
@@ -139,13 +139,16 @@ public class GraphicsTestApplication implements GameApplication
 		graphics.draw(world);
 		world.update();
 		
+		// (cdc - 4/3/2014): Commented out, b/c update was being called twice. Additionally,
+		// the game is extremely jittery when this is used instead of calling update continuously.
+		
 		// Ensure that the world is only updated as frequently as MILLIS_PER_TICK. 
-		long currentMillis = System.currentTimeMillis();
-		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
-		{
-			world.update();
-			lastUpdate = currentMillis;
-		}
+//		long currentMillis = System.currentTimeMillis();
+//		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
+//		{
+//			world.update();
+//			lastUpdate = currentMillis;
+//		}
 	}
 	
 	/**

--- a/bubolo/test/bubolo/integration/NetClientTestApplication.java
+++ b/bubolo/test/bubolo/integration/NetClientTestApplication.java
@@ -64,12 +64,12 @@ public class NetClientTestApplication implements GameApplication
 	/**
 	 * The number of game ticks (calls to <code>update</code>) per second.
 	 */
-	public static final int TICKS_PER_SECOND = 30;
+	public static final long TICKS_PER_SECOND = 30;
 	
 	/**
 	 * The number of milliseconds per game tick.
 	 */
-	public static final float MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
+	public static final long MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
 	
 	/**
 	 * Constructs an instance of the game application. Only one instance should 
@@ -134,13 +134,16 @@ public class NetClientTestApplication implements GameApplication
 		world.update();
 		network.update(world);
 		
+		// (cdc - 4/3/2014): Commented out, b/c update was being called twice. Additionally,
+		// the game is extremely jittery when this is used instead of calling update continuously.
+		
 		// Ensure that the world is only updated as frequently as MILLIS_PER_TICK. 
-		long currentMillis = System.currentTimeMillis();
-		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
-		{
-			world.update();
-			lastUpdate = currentMillis;
-		}
+//		long currentMillis = System.currentTimeMillis();
+//		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
+//		{
+//			world.update();
+//			lastUpdate = currentMillis;
+//		}
 	}
 	
 	/**

--- a/bubolo/test/bubolo/integration/NetServerTestApplication.java
+++ b/bubolo/test/bubolo/integration/NetServerTestApplication.java
@@ -47,12 +47,12 @@ public class NetServerTestApplication implements GameApplication
 	/**
 	 * The number of game ticks (calls to <code>update</code>) per second.
 	 */
-	public static final int TICKS_PER_SECOND = 30;
+	public static final long TICKS_PER_SECOND = 30;
 	
 	/**
 	 * The number of milliseconds per game tick.
 	 */
-	public static final float MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
+	public static final long MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
 	
 	/**
 	 * Constructs an instance of the game application. Only one instance should 
@@ -116,13 +116,16 @@ public class NetServerTestApplication implements GameApplication
 		world.update();
 		network.update(world);
 		
+		// (cdc - 4/3/2014): Commented out, b/c update was being called twice. Additionally,
+		// the game is extremely jittery when this is used instead of calling update continuously.
+		
 		// Ensure that the world is only updated as frequently as MILLIS_PER_TICK. 
-		long currentMillis = System.currentTimeMillis();
-		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
-		{
-			world.update();
-			lastUpdate = currentMillis;
-		}
+//		long currentMillis = System.currentTimeMillis();
+//		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
+//		{
+//			world.update();
+//			lastUpdate = currentMillis;
+//		}
 	}
 	
 	/**

--- a/bubolo/test/bubolo/integration/ParserTestApplication.java
+++ b/bubolo/test/bubolo/integration/ParserTestApplication.java
@@ -43,12 +43,12 @@ public class ParserTestApplication implements GameApplication
 	/**
 	 * The number of game ticks (calls to <code>update</code>) per second.
 	 */
-	public static final int TICKS_PER_SECOND = 30;
+	public static final long TICKS_PER_SECOND = 30;
 
 	/**
 	 * The number of milliseconds per game tick.
 	 */
-	public static final float MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
+	public static final long MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
 
 	/**
 	 * Constructs an instance of the game application. Only one instance should ever
@@ -116,13 +116,16 @@ public class ParserTestApplication implements GameApplication
 		graphics.draw(world);
 		world.update();
 
+		// (cdc - 4/3/2014): Commented out, b/c update was being called twice. Additionally,
+		// the game is extremely jittery when this is used instead of calling update continuously.
+		
 		// Ensure that the world is only updated as frequently as MILLIS_PER_TICK.
-		long currentMillis = System.currentTimeMillis();
-		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
-		{
-			world.update();
-			lastUpdate = currentMillis;
-		}
+//		long currentMillis = System.currentTimeMillis();
+//		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
+//		{
+//			world.update();
+//			lastUpdate = currentMillis;
+//		}
 	}
 
 	/**

--- a/bubolo/test/bubolo/integration/PillboxControllerTestApplication.java
+++ b/bubolo/test/bubolo/integration/PillboxControllerTestApplication.java
@@ -44,12 +44,12 @@ public class PillboxControllerTestApplication implements GameApplication
 	/**
 	 * The number of game ticks (calls to <code>update</code>) per second.
 	 */
-	public static final int TICKS_PER_SECOND = 30;
+	public static final long TICKS_PER_SECOND = 30;
 	
 	/**
 	 * The number of milliseconds per game tick.
 	 */
-	public static final float MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
+	public static final long MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
 	
 	/**
 	 * Constructs an instance of the game application. Only one instance should 
@@ -112,13 +112,16 @@ public class PillboxControllerTestApplication implements GameApplication
 		graphics.draw(world);
 		world.update();
 		
+		// (cdc - 4/3/2014): Commented out, b/c update was being called twice. Additionally,
+		// the game is extremely jittery when this is used instead of calling update continuously.
+		
 		// Ensure that the world is only updated as frequently as MILLIS_PER_TICK. 
-		long currentMillis = System.currentTimeMillis();
-		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
-		{
-			world.update();
-			lastUpdate = currentMillis;
-		}
+//		long currentMillis = System.currentTimeMillis();
+//		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
+//		{
+//			world.update();
+//			lastUpdate = currentMillis;
+//		}
 	}
 	
 	/**

--- a/bubolo/test/bubolo/integration/TankControllerTestApplication.java
+++ b/bubolo/test/bubolo/integration/TankControllerTestApplication.java
@@ -43,12 +43,12 @@ public class TankControllerTestApplication implements GameApplication
 	/**
 	 * The number of game ticks (calls to <code>update</code>) per second.
 	 */
-	public static final int TICKS_PER_SECOND = 30;
+	public static final long TICKS_PER_SECOND = 30;
 	
 	/**
 	 * The number of milliseconds per game tick.
 	 */
-	public static final float MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
+	public static final long MILLIS_PER_TICK = 1000 / TICKS_PER_SECOND;
 	
 	/**
 	 * Constructs an instance of the game application. Only one instance should 
@@ -107,13 +107,16 @@ public class TankControllerTestApplication implements GameApplication
 		graphics.draw(world);
 		world.update();
 		
+		// (cdc - 4/3/2014): Commented out, b/c update was being called twice. Additionally,
+		// the game is extremely jittery when this is used instead of calling update continuously.
+		
 		// Ensure that the world is only updated as frequently as MILLIS_PER_TICK. 
-		long currentMillis = System.currentTimeMillis();
-		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
-		{
-			world.update();
-			lastUpdate = currentMillis;
-		}
+//		long currentMillis = System.currentTimeMillis();
+//		if (currentMillis > (lastUpdate + MILLIS_PER_TICK))
+//		{
+//			world.update();
+//			lastUpdate = currentMillis;
+//		}
 	}
 	
 	/**


### PR DESCRIPTION
Partially fixed issues that Patrick identified:
- The ticks per milliseconds calculation was wrong in multiple integration tests (but not in sprint 1 or the primary game application)
- The millis per tick constant should be a long
- Commented out the frame limiter code in most integration tests, which wasn't working anyway. Using it causes the game to become very jittery. We'll need to research this further - the jitter is likely because the movement values are incorrect for the FPS.

I didn't touch the Sprint 2 application, since that was a deliverable.

We should add the frame limiter in the future, or something similar, since currently our game may now run at different speeds on different computers (i.e., the world.update method may be called at different rates). The libgdx library prevents it from being called as fast as possible, which is probably why we didn't notice this problem before.
